### PR TITLE
Relax style-src CSP directive

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -26,6 +26,9 @@
             - https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
             - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
+          style-src:
+            - unsafe-inline: Dynamic HTML created when clicking the "Copy signature" button
+
           img-src:
             - https://readifysignatures.blob.core.windows.net: Purple logo in the signature
 
@@ -35,7 +38,7 @@
           frame-ancestors:
             - https://teamtelstra.sharepoint.com: The app is embedded in a SharePoint page
         -->
-        <add name="Content-Security-Policy" value="script-src 'self'; style-src 'self'; img-src 'self' https://readifysignatures.blob.core.windows.net; connect-src https://login.microsoftonline.com; frame-ancestors https://teamtelstra.sharepoint.com; report-uri https://telstrapurple.report-uri.com/r/d/csp/enforce" />
+        <add name="Content-Security-Policy" value="script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://readifysignatures.blob.core.windows.net; connect-src https://login.microsoftonline.com; frame-ancestors https://teamtelstra.sharepoint.com; report-uri https://telstrapurple.report-uri.com/r/d/csp/enforce" />
       </customHeaders>
     </httpProtocol>
   </system.webServer>


### PR DESCRIPTION
Clicking the "Copy signature" button creates a hidden `<div>` with inline styles.
Fixes #72.